### PR TITLE
Fix empty proc error

### DIFF
--- a/lib/sequel/factory.rb
+++ b/lib/sequel/factory.rb
@@ -78,8 +78,8 @@ module Sequel
 
     # Gets/sets the factory with the given +name+. If a block is given, uses that
     # block to create a new factory.
-    def self.factory(name=:default)
-      factories[name] = Factory.new(Proc.new) if block_given?
+    def self.factory(name=:default, &block)
+      factories[name] = Factory.new(Proc.new(&block)) if block_given?
       factories[name]
     end
 


### PR DESCRIPTION
Hi, I came accross your gem and it works well but I was getting an error when trying to set it up:

```
/home/renatolond/sources/apptweak/sequel-factory/lib/sequel/factory.rb:83:in `new': tried to create Proc object without a block (ArgumentError)

      factories[name] = Factory.new(Proc.new(block)) if block_given?
                                             ^^^^^
        from /home/renatolond/sources/apptweak/sequel-factory/lib/sequel/factory.rb:83:in `factory'
```

I don't know if it's maybe related to my ruby version, but this change seems to fix it. I tested the fix on ruby 3.2.x